### PR TITLE
Error handling added

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
-const { ApolloServer, gql } = require('apollo-server');
-const { connect, model, Schema } = require('mongoose');
+const { ApolloServer } = require('apollo-server');
+const { connect } = require('mongoose');
 const url = require('./src/db/config');
 const typeDefs = require('./src/typeDefs');
 const resolvers = require('./src/resolvers');
@@ -8,7 +8,21 @@ const port = process.env.PORT || 3000;
 
 const server = new ApolloServer({
     typeDefs,
-    resolvers
+    resolvers,
+    csrfPrevention: true,
+    cache: "bounded",
+    formatError: (err) => {
+        if (err.message.startsWith('Database Error: ')) {
+            return new Error('Internal server error');
+        }
+
+        return err;
+    },
+    formatError(err) {
+        if (err.originalError instanceof AuthenticationError) {
+            return new Error('Invalid Authentication');
+        }
+    },
 });
 
 connect(url)


### PR DESCRIPTION
GraphQL handles errors a bit differently than REST. I added some all-encompassing error handles since I can't create a try/catch block that spits out errors.  